### PR TITLE
Serve assets in development

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -118,9 +118,13 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.1/howto/static-files/
 
 if DEBUG:
-    STATIC_URL = '/frontend/public/'
+    # Note the slashes '/.../' are necessary for STATIC_URL
+    STATIC_URL = '/frontend/dist/static/'
+
     STATICFILES_DIRS = [
-        # First locate the built assets
+        # First locate the built assets. When static files with the same names
+        # exist in both directories, the ones from dist will be loaded since
+        # they're compiled assets (e.g. index.html).
         os.path.join(BASE_DIR, 'frontend/dist'),
         os.path.join(BASE_DIR, 'frontend/public'),
     ]

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -14,8 +14,18 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.conf import settings
+from django.urls import path, re_path
+
+from .views import serve_dev_assets
+
 
 urlpatterns = [
     path('admin/', admin.site.urls),
 ]
+
+if settings.DEBUG:
+    # Since we use Django to serve the static assets during development, we add
+    # a fallback view to handle these requests. Note pattern /.*/ matches any
+    # URLs; thus it has to be added at the end of the URL patterns list.
+    urlpatterns.append(re_path(r'.*', serve_dev_assets))

--- a/backend/views.py
+++ b/backend/views.py
@@ -1,0 +1,12 @@
+from django.contrib.staticfiles.views import serve
+
+
+def serve_dev_assets(request):
+    """Serving compiled JS assets during development
+
+    During development, Django collects the static files so we can serve them
+    via this view.
+    """
+    if request.path == '/':
+        return serve(request, 'index.html')
+    return serve(request, request.path)


### PR DESCRIPTION
Add a view to serve the static files through Django. Since the development file serving in Django is pretty primitive and does not treat `index.html` differently, we redirect `/` to `index.html` by ourselves.

It would resolve #1.
