### PR TITLE
Serve assets in production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,10 @@ __pycache__/
 
 # Jetbrains IDEs
 /.idea
+
+# Django static root
+#
+# The static directory is only used in production. When the app starts, we
+# check out the latest index.html from the CDN into this directory
+# (backend/wsgi.py). The other static assets are served from the CDN directly.
+/static

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = '#6zwu&dq_5z5s6nkgzwb1nc40863jq4znvx5j)#%+sns_@7&1u'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get('PARROT_ENV', 'development')  != 'production'
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['localhost', '127.0.0.1', '[::1]']
 
 
 # Application definition
@@ -47,6 +47,8 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    # We use WhiteNoise to serve static files (index.html) using gunicorn
+    'whitenoise.middleware.WhiteNoiseMiddleware',
 ]
 
 ROOT_URLCONF = 'backend.urls'
@@ -125,4 +127,11 @@ if DEBUG:
         os.path.join(BASE_DIR, 'frontend/public'),
     ]
 else:
-    STATIC_URL = os.environ['PARROT_CDN_URL']
+    STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+
+    # http://whitenoise.evans.io/en/stable/django.html
+    # Serve index.html when visit /
+    WHITENOISE_INDEX_FILE = True
+
+    # Allow the app being hosted on PARROT_HOST to prevent Host Header Attack
+    ALLOWED_HOSTS.append(os.environ['PARROT_HOST'])

--- a/backend/wsgi.py
+++ b/backend/wsgi.py
@@ -10,7 +10,14 @@ https://docs.djangoproject.com/en/2.1/howto/deployment/wsgi/
 import os
 
 from django.core.wsgi import get_wsgi_application
+import urllib.request
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend.settings')
+
+# Retrive the index file from the CDN
+index = 'index.html'
+urllib.request.urlretrieve(
+    os.environ['PARROT_CDN_HOST'] + '/' + index,
+    'static/' + index)
 
 application = get_wsgi_application()

--- a/backend/wsgi.py
+++ b/backend/wsgi.py
@@ -9,15 +9,17 @@ https://docs.djangoproject.com/en/2.1/howto/deployment/wsgi/
 
 import os
 
+from django.conf import settings
 from django.core.wsgi import get_wsgi_application
 import urllib.request
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend.settings')
 
-# Retrive the index file from the CDN
-index = 'index.html'
-urllib.request.urlretrieve(
-    os.environ['PARROT_CDN_HOST'] + '/' + index,
-    'static/' + index)
+if not settings.DEBUG:
+    # Retrive the index file from the CDN in production
+    index = 'index.html'
+    urllib.request.urlretrieve(
+        os.environ['PARROT_CDN_HOST'] + '/' + index,
+        'static/' + index)
 
 application = get_wsgi_application()

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "react-scripts start",
     "watch": "node watch.js",
-    "build": "react-scripts build",
+    "build": "PUBLIC_URL=$PARROT_CDN_HOST react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,13 @@
+boto3==1.9.91
+botocore==1.12.91
 Django==2.1.5
+docutils==0.14
 gunicorn==19.9.0
+jmespath==0.9.3
+python-dateutil==2.8.0
 pytz==2018.9
+s3transfer==0.2.0
+six==1.12.0
+tqdm==4.31.1
+urllib3==1.24.1
+whitenoise==4.1.2

--- a/scripts/deploy_frontend.py
+++ b/scripts/deploy_frontend.py
@@ -1,0 +1,55 @@
+from mimetypes import MimeTypes
+from tqdm import tqdm
+import boto3
+import glob
+import os
+import time
+
+
+# Create boto3 clients
+s3 = boto3.client(
+    's3',
+    aws_access_key_id=os.environ['PARROT_AWS_KEY_ID'],
+    aws_secret_access_key=os.environ['PARROT_AWS_KEY_SECRET'])
+cf = boto3.client(
+    'cloudfront',
+    aws_access_key_id=os.environ['PARROT_AWS_KEY_ID'],
+    aws_secret_access_key=os.environ['PARROT_AWS_KEY_SECRET'])
+# Read our targets
+bucket = os.environ['PARROT_CDN_BUCKET']
+dist = os.environ['PARROT_CDN_DIST']
+
+print('Uploading files...')
+mime = MimeTypes()
+for filename in tqdm(glob.glob('frontend/build/**/*', recursive=True)):
+    if not os.path.isdir(filename):
+        # Try to fill the MIME type based on the filename. If we cannot make a
+        # guess, then we assume it's a binary file.
+        mime_type =  mime.guess_type(filename)[0]
+        if mime_type is None:
+            mime_type = 'application/octet-stream'
+        # Upload the file to the s3 bucket with read permission
+        s3.upload_file(
+                filename,
+                bucket,
+                # The new filename on s3. We want to remove the frontend/build/
+                # prefix from the name.
+                filename.split('frontend/build/')[-1],
+                ExtraArgs={
+                    'ACL': 'public-read',
+                    'ContentType': mime_type,
+                })
+print('Done.')
+
+print('Creating invalidation...')
+# Invaliate all assets caches on CloudFront
+cf.create_invalidation(
+    DistributionId=dist,
+    InvalidationBatch={
+        'Paths': {
+            'Quantity': 1,
+            'Items': ['/*']
+        },
+        'CallerReference': str(time.time()),
+    })
+print('Done.')


### PR DESCRIPTION
This PR introduces changes to deploy this project and serve assets in production.
- Checkout a latest index.html from the CDN
- Use WhiteNoise to serve static files (index.html) with gunicorn
- Use boto3 to sync the compiled assets onto S3 and invalidate the cache

The production site now is available at https://www.progteam.org (yes, I got us a new domain just to stay consistent with the GitHub org name 😄).

Here are more details. I'm planning to add this into our wiki.

Deployment
===
Deployment needs to be done for the **frontend** and **backend** separately and in this order. Deploying is a privileged operation so be careful.

### Environment Variables
We need to have access to those environment variables when we deploy
- `PARROT_AWS_KEY_ID`: The AWS key ID. The deployment script requires it to connect to AWS resources.
- `PARROT_AWS_KEY_SECRET`: The AWS key secret. The deployment script requires it to connect to AWS resources.
- `PARROT_CDN_BUCKET`: Identify the s3 bucket we used for the CDN.
- `PARROT_CDN_DIST`: Identify the CloudFront distro we used for the CDN.
- `PARROT_CDN_HOST`: The CDN host for the static assets.
- `PARROT_ENV`: The development environment. Currently it can be `development` (default) or `production`.
- `PARROT_HOST`: Whitelist the main host in production.

Note: we don't want to share the values of many of these variables publicly (e.g. `PARROT_AWS_KEY_ID` and `PARROT_AWS_KEY_SECRET`) or there may be disastrous consequences.

## Deploy the frontend
To deploy the frontend, one must build the frontend first
```
npm run build -C frontend
```
Then run the script to deploy it.
```
python scripts/deploy_frontend.py
```

## Deploy the backend
We need only need to push it to Heroku.
```
git push heroku master -f
```
where `heroku` is a git remote pointing to `https://git.heroku.com/progteam-parrot.git`.
Try to fill the MIME type based on the filename. If we cannot make a guess, then we assume it's a binary file. 