### PR TITLE
[Landing Page] Add content

### DIFF
--- a/frontend/src/_breakpoints.scss
+++ b/frontend/src/_breakpoints.scss
@@ -1,0 +1,164 @@
+/*
+ * Breakpoints
+ *
+ *  @include breakpoint-all:
+ *    The style will be applied to all settings.
+ *
+ *  @include breakpoint-<bp in $breakpoints>-<down/only/up>
+ *    Apply the style when the window width is in
+ *      down: [0, next(bp))
+ *      only: [bt, next(bp))
+ *      up: [bt, MAX_WIDTH)
+ */
+
+$breakpoints: (
+  'mobile-m': 0px,
+  'mobile-l': 376px,
+  'tablet': 426px,
+  'laptop-m': 769px,
+  'laptop-l': 1025px,
+  'desktop-m': 1440px,
+  'desktop-l': 2560px,
+);
+
+@mixin breakpoint-all {
+  $value: map-get($breakpoints, mobile-m);
+
+  @media (min-width: $value) {
+    @content;
+  }
+}
+
+@mixin breakpoint-mobile-m-only {
+  $min-value: map-get($breakpoints, mobile-m);
+  $max-value: map-get($breakpoints, mobile-l) - 1;
+
+  @media (min-width: $min-value) and (max-width: $max-value) {
+    @content;
+  }
+}
+
+@mixin breakpoint-mobile-l-only {
+  $min-value: map-get($breakpoints, mobile-l);
+  $max-value: map-get($breakpoints, tablet) - 1;
+
+  @media (min-width: $min-value) and (max-width: $max-value) {
+    @content;
+  }
+}
+
+@mixin breakpoint-mobile-l-down {
+  $max-value: map-get($breakpoints, tablet) - 1;
+
+  @media (max-width: $max-value) {
+    @content;
+  }
+}
+
+@mixin breakpoint-mobile-l-up {
+  $min-value: map-get($breakpoints, mobile-l);
+
+  @media (min-width: $min-value) {
+    @content;
+  }
+}
+
+@mixin breakpoint-tablet-only {
+  $min-value: map-get($breakpoints, tablet);
+  $max-value: map-get($breakpoints, laptop-m) - 1;
+
+  @media (min-width: $min-value) and (max-width: $max-value) {
+    @content;
+  }
+}
+
+@mixin breakpoint-tablet-down {
+  $max-value: map-get($breakpoints, laptop-m) - 1;
+
+  @media (max-width: $max-value) {
+    @content;
+  }
+}
+
+@mixin breakpoint-tablet-up {
+  $min-value: map-get($breakpoints, tablet);
+
+  @media (min-width: $min-value) {
+    @content;
+  }
+}
+
+@mixin breakpoint-laptop-m-only {
+  $min-value: map-get($breakpoints, laptop-m);
+  $max-value: map-get($breakpoints, laptop-l) - 1;
+
+  @media (min-width: $min-value) and (max-width: $max-value) {
+    @content;
+  }
+}
+
+@mixin breakpoint-laptop-m-down {
+  $max-value: map-get($breakpoints, laptop-l) - 1;
+
+  @media (max-width: $max-value) {
+    @content;
+  }
+}
+
+@mixin breakpoint-laptop-m-up {
+  $min-value: map-get($breakpoints, laptop-m);
+
+  @media (min-width: $min-value) {
+    @content;
+  }
+}
+
+@mixin breakpoint-laptop-l-only {
+  $min-value: map-get($breakpoints, laptop-l);
+  $max-value: map-get($breakpoints, desktop-m) - 1;
+
+  @media (min-width: $min-value) and (max-width: $max-value) {
+    @content;
+  }
+}
+
+@mixin breakpoint-laptop-l-down {
+  $max-value: map-get($breakpoints, desktop-m) - 1;
+
+  @media (max-width: $max-value) {
+    @content;
+  }
+}
+
+@mixin breakpoint-laptop-l-up {
+  $min-value: map-get($breakpoints, laptop-l);
+
+  @media (min-width: $min-value) {
+    @content;
+  }
+}
+
+@mixin breakpoint-desktop-m-only {
+  $min-value: map-get($breakpoints, desktop-m);
+  $max-value: map-get($breakpoints, desktop-l) - 1;
+
+  @media (min-width: $min-value) and (max-width: $max-value) {
+    @content;
+  }
+}
+
+@mixin breakpoint-desktop-m-down {
+  $max-value: map-get($breakpoints, desktop-l) - 1;
+
+  @media (max-width: $max-value) {
+    @content;
+  }
+}
+
+@mixin breakpoint-desktop-m-up {
+  $min-value: map-get($breakpoints, desktop-m);
+
+  @media (min-width: $min-value) {
+    @content;
+  }
+}

--- a/frontend/src/_colors.scss
+++ b/frontend/src/_colors.scss
@@ -3,3 +3,5 @@
  */
 
 $logo-color: #1F346B;
+$primary-color: #000000;
+$backgroud-color-light: #ececec;

--- a/frontend/src/_guest_page.scss
+++ b/frontend/src/_guest_page.scss
@@ -1,0 +1,20 @@
+$guest-page-min-width: 200px;
+
+%guest-page {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  min-width: $guest-page-min-width;
+
+  .main {
+    flex: 1 100%;
+    /* Another flex box to align its children vertically */
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+
+    p {
+      width: 100%;
+    }
+  }
+}

--- a/frontend/src/components/guest_nav.js
+++ b/frontend/src/components/guest_nav.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import Logo from './logo'
+
+import './guest_nav.scss';
+
+class GuestNav extends React.Component {
+  render() {
+    return (
+      <div className='guest-nav'>
+        <Logo />
+      </div>
+    );
+  }
+}
+
+export default GuestNav;

--- a/frontend/src/components/guest_nav.scss
+++ b/frontend/src/components/guest_nav.scss
@@ -1,0 +1,3 @@
+.guest-nav {
+  padding: 20px;
+}

--- a/frontend/src/components/logo.scss
+++ b/frontend/src/components/logo.scss
@@ -1,6 +1,7 @@
 @import '../colors';
 
 .logo {
+  min-width: 150px;
   width: 50%;
   max-width: 300px;
   height: auto;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import './index.scss';
 import LandingPage from './landing/landing'
+
+import './index.scss';
 
 class App extends React.Component {
   render() {

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -1,4 +1,19 @@
-body {
+/* CSS Reset */
+
+html {
+  box-sizing: border-box;
+  font-size: 14px;
+}
+
+*, *:before, *:after {
+  box-sizing: inherit;
+}
+
+a:hover, a:visited, a:link, a:active {
+  text-decoration: none;
+}
+
+body, h1, h2, h3, h4, h5, h6, p, ol, ul {
   /* Default Font Fallback Stacks */
   font-family:
     -apple-system,
@@ -10,4 +25,6 @@ body {
     Cantarell,
     Helvetica Neue,
     sans-serif;
+  margin: 0;
+  padding: 0;
 }

--- a/frontend/src/landing/landing.js
+++ b/frontend/src/landing/landing.js
@@ -1,15 +1,23 @@
 import React from 'react';
 
-import Logo from '../components/logo'
+import GuestNav from '../components/guest_nav';
+import LandingFooter from './landing_footer';
 
-class LandingPage extends React.Component {
-  render() {
-    return (
-      <div>
-        <Logo />
+import './landing.scss';
+
+const LandingPage = (props) => {
+  return (
+    <div className='landing'>
+      <GuestNav />
+      <div className='main'>
+        <p>
+          We choose to be
+          <strong>better</strong>
+        </p>
       </div>
-    );
-  }
-}
+      <LandingFooter />
+    </div>
+  );
+};
 
 export default LandingPage;

--- a/frontend/src/landing/landing.scss
+++ b/frontend/src/landing/landing.scss
@@ -1,0 +1,29 @@
+@import '../guest_page';
+@import '../breakpoints';
+
+$landing-msg-font-size: 54px;
+
+.landing {
+  @extend %guest-page;
+
+  .main {
+    p {
+      /* Adjust margin-bottom to center the message vertically */
+      font-size: $landing-msg-font-size;
+      margin-bottom: $landing-msg-font-size;
+      text-align: center;
+      width: 100%;
+
+      @include breakpoint-mobile-m-only {
+        $landing-msg-font-size: 25px;
+        font-size: $landing-msg-font-size;
+        margin-bottom: $landing-msg-font-size;
+      }
+
+      strong {
+        display: block;
+        background: #CCCCCC;
+      }
+    }
+  }
+}

--- a/frontend/src/landing/landing_footer.js
+++ b/frontend/src/landing/landing_footer.js
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import './landing_footer.scss';
+
+const FooterLink = (props) => {
+  return (
+    <a
+      target='_blank'
+      rel='noopener noreferrer'
+      href={props.href}>
+      {props.children}
+    </a>
+  );
+};
+
+const LandingFooter = (props) => {
+  return (
+    <div className='landing-footer'>
+      <FooterLink href='https://csumb.edu/'>
+        CSUMB
+      </FooterLink>
+      <FooterLink href='https://github.com/progteam'>
+        GitHub
+      </FooterLink>
+      <FooterLink href='https://open.kattis.com/universities/csumb.edu'>
+        Kattis
+      </FooterLink>
+    </div>
+  );
+};
+
+export default LandingFooter;

--- a/frontend/src/landing/landing_footer.scss
+++ b/frontend/src/landing/landing_footer.scss
@@ -1,0 +1,19 @@
+@import '../breakpoints';
+@import '../colors';
+
+.landing-footer {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  background-color: $backgroud-color-light;
+
+  a {
+    font-size: 14px;
+    color: $primary-color;
+    margin: 10px;
+
+    @include breakpoint-tablet-down {
+      font-size: 12px;
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces two commits:

### Update styling
- Add a min(max)-width to the logo so it can be displayed properly on different devices
- Add breakpoints to apply styles for different window widths
- Add CSS reset
- Add guest-page base style

### Add content
- Create a Nav component for the landing page
- Add a footer which contains some links
- Add a message: "We choose to be better". 

Well, It pops out of my head randomly. Comments/suggestions are welcome!

Now the site should look like this:
<img width="797" alt="screen shot 2019-02-22 at 9 49 35 am" src="https://user-images.githubusercontent.com/17794071/53260784-363d9080-3687-11e9-9846-3eeb06514a7b.png">