### PR TITLE
Django version update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Django==2.1.6
+Django==2.1.7
 gunicorn==19.9.0
 pytz==2018.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Django==2.1.5
+Django==2.1.6
 gunicorn==19.9.0
 pytz==2018.9


### PR DESCRIPTION
### Django version updated to 2.1.7

Reason for the version update:

> Django 1.11.x before 1.11.19, 2.0.x before 2.0.11, and 2.1.x before 2.1.6 allows Uncontrolled Memory Consumption via a malicious attacker-supplied value to the django.utils.numberformat.format() function.