### PR TITLE
[About Page] Add views

### DIFF
--- a/backend/about/test_views.py
+++ b/backend/about/test_views.py
@@ -1,0 +1,45 @@
+import json
+from django.test import TestCase
+
+class AboutPageViewTests(TestCase):
+    fixtures = [
+        'meetinginfo.json',
+        'officerinfo.json',
+        'progteamdesc.json',
+    ]
+
+    def test_meeting_info(self):
+        """Test route /about/meeting-info
+        - it returns status code 200
+        - it returns a non-empty list
+        """
+        response = self.client.get('/about/meeting-info')
+        self.assertEqual(response.status_code, 200)
+
+        obj = json.loads(response.content)
+        self.assertTrue(isinstance(obj, list))
+        self.assertTrue(len(obj) > 0)
+
+    def test_officer_info(self):
+        """Test route /about/officer-info
+        - it returns status code 200
+        - it returns a non-empty list
+        """
+        response = self.client.get('/about/officer-info')
+        self.assertEqual(response.status_code, 200)
+
+        obj = json.loads(response.content)
+        self.assertTrue(isinstance(obj, list))
+        self.assertTrue(len(obj) > 0)
+
+    def test_progteam_desc(self):
+        """Test route /about/progteam-desc
+        - it returns status code 200
+        - it has a non-empty description
+        """
+        response = self.client.get('/about/progteam-desc')
+        self.assertEqual(response.status_code, 200)
+
+        obj = json.loads(response.content)
+        self.assertTrue('desc' in obj)
+        self.assertTrue(len(obj['desc']) > 0)

--- a/backend/about/urls.py
+++ b/backend/about/urls.py
@@ -1,0 +1,15 @@
+"""
+backend/about/urls.py
+
+The `urlpatterns` list routes URLs to views. For more information please see:
+    https://docs.djangoproject.com/en/2.1/topics/http/urls/
+"""
+from django.urls import path
+from .views import progteam_desc, meeting_info, officer_info
+
+# pylint: disable=invalid-name
+urlpatterns = [
+    path('meeting-info', meeting_info),
+    path('officer-info', officer_info),
+    path('progteam-desc', progteam_desc),
+]

--- a/backend/about/views.py
+++ b/backend/about/views.py
@@ -1,0 +1,59 @@
+"""
+backend/about/views.py
+
+Views for the about page
+- progteam_desc
+- meeting_info
+- officer_info
+"""
+from django.http import JsonResponse
+from .models import MeetingInfo, OfficerInfo, ProgteamDesc
+
+
+def meeting_info(request):
+    """backend.about.urls: /about/meeting-info
+
+    Meeting Information
+    TODO: We're returning all the meeting information. This requires admins
+    edit existing meetings (or delete the old ones). An alternative way is to
+    filter the meeting info by the current academic term.
+    """
+    fmt = '%I:%M %p'
+    meetings = map(
+        lambda obj: {
+            'dayOfWeek': obj.day_of_week,
+            'room': obj.room,
+            'term': obj.term,
+            'timeStart': obj.time_start.strftime(fmt),
+            'timeEnd': obj.time_end.strftime(fmt),
+        }, MeetingInfo.objects.all())
+    return JsonResponse(list(meetings), safe=False)
+
+
+def officer_info(request):
+    """backend.about.urls: /about/officer-info
+
+    Officer Information
+    TODO: Similar to the TODO item in backend.about.views.meeting_info
+    """
+    officers = map(
+        lambda obj: {
+            'email': obj.email,
+            'name': obj.name,
+            'profileImg': obj.profile_img,
+            'role': obj.role,
+            'term': obj.term,
+        }, OfficerInfo.objects.all())
+    return JsonResponse(list(officers), safe=False)
+
+
+def progteam_desc(request):
+    """backend.about.urls: /about/progteam-desc
+
+    Progteam team description. We assume there is only one description object
+    lives in the table, and returns the first and only one.
+    """
+    obj = ProgteamDesc.objects.first()
+    return JsonResponse({
+        'desc': obj.desc,
+    })

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -15,7 +15,7 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.conf import settings
-from django.urls import path, re_path
+from django.urls import include, path, re_path
 
 from .views import error404, index, serve_dev_assets
 
@@ -23,6 +23,7 @@ from .views import error404, index, serve_dev_assets
 # pylint: disable=invalid-name
 urlpatterns = [
     path('', index),
+    path('about/', include('backend.about.urls')),
     path('admin/', admin.site.urls),
 ]
 


### PR DESCRIPTION
- Add views for the about page and their tests
  - progteam_desc
  - meeting_info
  - officer_info
- Check-in test fixtures (most of them happen to be real data)

Here is a sample response from `/about/meeting-info`
```
[{"day_of_week": "monday", "room": "BIT 223", "term": "SPR 19", "time_start": "04:00 PM", "time_end": "06:00 PM"}, {"day_of_week": "tuesday", "room": "BIT 235", "term": "SPR 19", "time_start": "12:00 PM", "time_end": "02:00 PM"}, {"day_of_week": "wednesday", "room": "BIT 224", "term": "SPR 19", "time_start": "06:00 PM", "time_end": "08:00 PM"}]
```