### PR TITLE
[Fix] Run Pylint on all Python scripts

### DIFF
--- a/backend/about/test_views.py
+++ b/backend/about/test_views.py
@@ -1,7 +1,18 @@
+"""
+backend/about/test_views.py
+
+Tests for the about page views. We use the test client. Read more at
+    https://docs.djangoproject.com/en/2.1/topics/testing/tools/
+"""
 import json
 from django.test import TestCase
 
 class AboutPageViewTests(TestCase):
+    """About page view tests for URLs:
+    - /about/meeting-info
+    - /about/officer-info
+    - /about/progteam-desc
+    """
     fixtures = [
         'meetinginfo.json',
         'officerinfo.json',

--- a/backend/scoreboard/tests/test_command_prunekattisscore.py
+++ b/backend/scoreboard/tests/test_command_prunekattisscore.py
@@ -1,14 +1,13 @@
 """
 backend/scoreboard/test/test_command_prunekattisscore.py
 
-Tests for the prunekattisscore command in
-    backend/scoreboard/management/commands/prunekattisscore.py
+Tests for the prunekattisscore command. Read more at
+    https://docs.djangoproject.com/en/2.1/ref/django-admin/#django.core.management.call_command
 """
 from datetime import datetime, timedelta
 from unittest.mock import patch, Mock
 
 from django.core.management import call_command
-from django.db import models
 from django.test import TestCase
 from django.utils.timezone import get_current_timezone
 
@@ -30,6 +29,9 @@ def create_scores(num_scores, now, delta=timedelta(minutes=1)):
 
 
 class PruneKattisScoreTests(TestCase):
+    """Tests for the prunekattisscore command in
+        backend/scoreboard/management/commands/prunekattisscore.py
+    """
     def test_pruning(self):
         """Test the prunekattisscore command
         - it prunes the table and keeps x data points where x in

--- a/manage.py
+++ b/manage.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python
+"""
+A Django’s command-line utility for administrative tasks.
+
+This file is automatically created in each Django project. Read more at
+    https://docs.djangoproject.com/en/2.1/ref/django-admin/
+"""
 import os
 import sys
 

--- a/scripts/test_backend.sh
+++ b/scripts/test_backend.sh
@@ -15,5 +15,10 @@ echo "Testing backend using $PARROT_ENV environment..."
 python manage.py migrate && \
 python manage.py collectstatic --noinput && \
 python manage.py test && \
-# Run linter
-pylint --load-plugins pylint_django **/*.py
+# Run linter and exclude directories: penv, migrations, and node_modules
+find . -type d \( \
+  -name migrations -o \
+  -name node_modules -o \
+  -name penv \
+\) -prune -o -name "*.py" -print \
+| xargs pylint --load-plugins pylint_django


### PR DESCRIPTION
- Use find command to get all Python scripts and pipe them to Pylint
- Fix existing lint errors

Run (as part of the command in `scripts/test_backend.sh`)
```
find . -type d \( \
  -name migrations -o \
  -name node_modules -o \
  -name penv \
\) -prune -o -name "*.py" -print
```
Then we see all the Python scripts are listed:
```
./manage.py
./scripts/deploy_frontend.py
./backend/scoreboard/models.py
./backend/scoreboard/management/commands/prunekattisscore.py
./backend/scoreboard/tests/__init__.py
./backend/scoreboard/tests/test_command_prunekattisscore.py
./backend/scoreboard/__init__.py
./backend/settings.py
./backend/retrieve_index_file.py
./backend/about/models.py
./backend/about/test_views.py
./backend/about/__init__.py
./backend/about/views.py
./backend/about/urls.py
./backend/__init__.py
./backend/wsgi.py
./backend/static_files_storage.py
./backend/test_redirect_404.py
./backend/views.py
./backend/urls.py
```